### PR TITLE
Migrate [project.optional-dependencies] to [dependency-groups] in pyproject.toml and update dev dependency management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ version = {attr = "adraitools.__version__"}
 [project.scripts]
 adr-ai-tools = "adraitools.cli:main"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest>=8.3.5",
     "ruff>=0.11.10",

--- a/uv.lock
+++ b/uv.lock
@@ -6,18 +6,19 @@ requires-python = ">=3.11"
 name = "adr-ai-tools-py"
 source = { editable = "." }
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "pytest" },
     { name = "ruff" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.10" },
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "ruff", specifier = ">=0.11.10" },
 ]
-provides-extras = ["dev"]
 
 [[package]]
 name = "colorama"


### PR DESCRIPTION
# Pull Request Overview
Reviewed how to manage dev dependencies in `pyproject.toml`.

## Changes
- Changed `[project.optional-dependencies]` section in pyproject.toml to `[dependency-groups]` to explicitly group development dependencies (pytest, ruff).
- Updated uv.lock.

## Related Issues
#3 

## Test Details
- Verified that the `uv pip install --group dev` command was used to properly install dependencies.

## Future Work
- None

## Notes
- None