### PR TITLE
feat: integrate configuration system with init command behavior

### DIFF
--- a/docs/adr/0027-protocol-types-for-test-fixtures.md
+++ b/docs/adr/0027-protocol-types-for-test-fixtures.md
@@ -1,0 +1,51 @@
+# ADR-0027: Protocol Types for Test Fixtures
+
+## Status
+Accepted
+
+## Date
+2025-07-17
+
+## Context
+Test fixtures traditionally lack proper type hints, making it difficult to understand fixture return types and catch type-related errors at development time. Without explicit interfaces, fixtures can have unclear contracts and provide poor IDE support.
+
+## Decision
+Adopt `typing.Protocol` for defining explicit fixture interfaces, providing type-safe contracts for test fixture functions.
+
+## Rationale
+Protocol types provide:
+- **Explicit Contracts**: Clear interfaces for fixture functions
+- **IDE Support**: Better autocompletion and type checking
+- **Runtime Safety**: Type checkers catch interface mismatches early
+- **Documentation**: Protocols serve as living documentation
+
+## Implications
+### Positive Implications
+- Type safety prevents runtime errors
+- Better developer experience with IDE support
+- Self-documenting fixture contracts
+
+### Concerns
+- Additional boilerplate code for type definitions
+- Learning curve for developers unfamiliar with Protocol types
+
+## Alternatives
+### Duck Typing with Type Comments
+- **Pros**: Minimal syntax overhead
+- **Cons**: Weak type safety, poor IDE support
+- **Rejected**: Insufficient type guarantees
+
+### Abstract Base Classes
+- **Pros**: Explicit inheritance relationships
+- **Cons**: Runtime overhead, rigid inheritance
+- **Rejected**: Protocols provide structural typing without inheritance
+
+## Future Direction
+- Migrate existing fixtures to use Protocol types
+- Create fixture templates for common patterns
+- Explore generic Protocol types for reusable patterns
+
+## References
+- [PEP 544 - Protocols: Structural subtyping](https://peps.python.org/pep-0544/)
+- [typing.Protocol documentation](https://docs.python.org/3/library/typing.html#typing.Protocol)
+- [ADR-0025: Shared Test Fixtures Pattern](./0025-shared-test-fixtures-pattern.md)

--- a/docs/adr/0028-structured-test-fixture-organization.md
+++ b/docs/adr/0028-structured-test-fixture-organization.md
@@ -1,0 +1,51 @@
+# ADR-0028: Structured Test Fixture Organization
+
+## Status
+Accepted
+
+## Date
+2025-07-17
+
+## Context
+Test fixtures often return complex data structures or multiple related objects. Without structured organization, fixture return values are accessed through unclear tuple unpacking or attribute access patterns, leading to maintenance issues and reduced code clarity.
+
+## Decision
+Use `NamedTuple` for structured fixture return values and implement layered fixture organization by test scope and responsibility.
+
+## Rationale
+- **Clear Structure**: NamedTuple provides named access to fixture components
+- **Type Safety**: Structured types enable better type checking
+- **Organization**: Layered fixtures separate concerns by test type and scope
+- **Maintainability**: Centralized fixture definitions reduce duplication
+
+## Implications
+### Positive Implications
+- Improved code readability with named attribute access
+- Better refactoring safety with structured types
+- Reduced test setup duplication across modules
+
+### Concerns
+- Slightly more verbose fixture definitions
+- Need to maintain NamedTuple definitions alongside implementations
+
+## Alternatives
+### Plain Tuple Returns
+- **Pros**: Minimal syntax
+- **Cons**: Unclear structure, positional access only
+- **Rejected**: Poor readability and maintainability
+
+### Dictionary Returns
+- **Pros**: Named access, flexible structure
+- **Cons**: No type safety, runtime key errors
+- **Rejected**: Lacks compile-time type checking
+
+## Future Direction
+- Migrate existing fixtures to use structured return types
+- Establish naming conventions for fixture organization
+- Consider fixture dependency optimization
+
+## References
+- [NamedTuple documentation](https://docs.python.org/3/library/typing.html#typing.NamedTuple)
+- [pytest fixtures documentation](https://docs.pytest.org/en/stable/fixture.html)
+- [ADR-0025: Shared Test Fixtures Pattern](./0025-shared-test-fixtures-pattern.md)
+- [ADR-0027: Protocol Types for Test Fixtures](./0027-protocol-types-for-test-fixtures.md)

--- a/src/adraitools/cli.py
+++ b/src/adraitools/cli.py
@@ -6,6 +6,7 @@ from typing import Annotated
 import typer
 
 from adraitools import __version__
+from adraitools.models.result import InitializationResult
 from adraitools.services.adr_initializer import AdrInitializer
 from adraitools.services.configuration_service import ConfigurationService
 from adraitools.services.file_system_service import FileSystemService
@@ -48,14 +49,26 @@ def init() -> None:
     # Dependency injection - create service instances
     file_system_service = FileSystemService()
     user_interaction_service = UserInteractionService()
-    initializer = AdrInitializer(file_system_service, user_interaction_service)
+    configuration_service = ConfigurationService()
+    initializer = AdrInitializer(
+        file_system_service, user_interaction_service, configuration_service
+    )
 
     # Execute initialization
     result = initializer.initialize()
 
+    # Handle result and provide user feedback
+    _handle_init_result(result, configuration_service)
+
+
+def _handle_init_result(
+    result: InitializationResult, configuration_service: ConfigurationService
+) -> None:
+    """Handle initialization result and provide appropriate user feedback."""
     if result.success:
-        typer.echo("Created docs/adr/ directory")
-        typer.echo("Generated template: docs/adr/0000-adr-template.md")
+        config = configuration_service.get_configuration()
+        typer.echo(f"Created {config.adr_directory}/ directory")
+        typer.echo(f"Generated template: {config.template_file}")
         typer.echo(
             "Ready to create your first ADR with: "
             'adr-ai-tools new "Your decision title"'

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,8 +1,33 @@
 """E2E test configuration."""
 
 from pathlib import Path
+from typing import NamedTuple, Protocol
 
+import pexpect
 import pytest
+
+
+class PexpectResult(NamedTuple):
+    """Result of pexpect command execution."""
+
+    exit_code: int
+    output: str
+
+
+class CommandRunner(Protocol):
+    """Protocol for command runner."""
+
+    def __call__(self, command: str, expect_patterns: list[str]) -> PexpectResult:
+        """Run command and expect patterns."""
+        ...
+
+
+class ConfigCreator(Protocol):
+    """Protocol for configuration creator."""
+
+    def __call__(self, config_data: dict[str, str]) -> Path:
+        """Create configuration file with given data."""
+        ...
 
 
 @pytest.fixture(autouse=True)
@@ -21,3 +46,53 @@ def test_dir(current_dir: Path) -> Path:
 def project_dir(test_dir: Path) -> Path:
     """The project directory."""
     return test_dir.parent
+
+
+@pytest.fixture
+def e2e_runner(isolated_e2e_env: Path) -> CommandRunner:
+    """Create command runner for E2E tests."""
+
+    def _run_command(command: str, expect_patterns: list[str]) -> PexpectResult:
+        """Run command and expect patterns."""
+        child = pexpect.spawn(command, cwd=isolated_e2e_env, encoding="utf-8")
+
+        output_lines = []
+        try:
+            for pattern in expect_patterns:
+                child.expect(pattern)
+                output_lines.append(child.before or "")
+
+            child.expect(pexpect.EOF)
+            child.close()
+
+            return PexpectResult(
+                exit_code=child.exitstatus or 0,
+                output="\n".join(output_lines),
+            )
+        except pexpect.exceptions.EOF:
+            child.close()
+            return PexpectResult(
+                exit_code=child.exitstatus or 1,
+                output="\n".join(output_lines),
+            )
+
+    return _run_command
+
+
+@pytest.fixture
+def config_creator(isolated_e2e_env: Path) -> ConfigCreator:
+    """Create configuration creator for E2E tests."""
+
+    def _create_config(config_data: dict[str, str]) -> Path:
+        """Create configuration file with given data."""
+        config_dir = isolated_e2e_env / ".adr-ai-tools"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        config_file = config_dir / "config.toml"
+
+        toml_content = "\n".join(
+            [f'{key} = "{value}"' for key, value in config_data.items()]
+        )
+        config_file.write_text(toml_content)
+        return config_file
+
+    return _create_config

--- a/tests/e2e/test_init_command.py
+++ b/tests/e2e/test_init_command.py
@@ -1,6 +1,5 @@
 """E2E tests for init command using pexpect."""
 
-import tempfile
 from pathlib import Path
 
 import pexpect
@@ -8,85 +7,81 @@ import pytest
 
 
 @pytest.mark.e2e
-def test_init_command_creates_directory_and_template() -> None:
+def test_init_command_creates_directory_and_template(isolated_e2e_env: Path) -> None:
     """Test that init command creates docs/adr directory and template file."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        # Run init command in temp directory
-        child = pexpect.spawn("uv run adr-ai-tools init", cwd=tmpdir)
-        child.expect_exact("Created docs/adr/ directory")
-        child.expect_exact("Generated template: docs/adr/0000-adr-template.md")
-        child.expect_exact(
-            "Ready to create your first ADR with: "
-            'adr-ai-tools new "Your decision title"'
-        )
-        child.expect(pexpect.EOF)
-        child.close()
+    # Run init command in temp directory
+    child = pexpect.spawn("uv run adr-ai-tools init", cwd=isolated_e2e_env)
+    child.expect_exact("Created docs/adr/ directory")
+    child.expect_exact("Generated template: docs/adr/0000-adr-template.md")
+    child.expect_exact(
+        'Ready to create your first ADR with: adr-ai-tools new "Your decision title"'
+    )
+    child.expect(pexpect.EOF)
+    child.close()
 
-        # Verify exit code
-        assert child.exitstatus == 0
+    # Verify exit code
+    assert child.exitstatus == 0
 
-        # Verify directory was created
-        adr_dir = Path(tmpdir) / "docs/adr"
-        assert adr_dir.exists()
-        assert adr_dir.is_dir()
+    # Verify directory was created
+    adr_dir = isolated_e2e_env / "docs/adr"
+    assert adr_dir.exists()
+    assert adr_dir.is_dir()
 
-        # Verify template file was created
-        template_file = adr_dir / "0000-adr-template.md"
-        assert template_file.exists()
-        assert template_file.is_file()
+    # Verify template file was created
+    template_file = adr_dir / "0000-adr-template.md"
+    assert template_file.exists()
+    assert template_file.is_file()
 
-        # Verify template content
-        content = template_file.read_text()
-        assert "# Architecture Decision Record (ADR)" in content
-        assert "## Title" in content
-        assert "## Status" in content
-        assert "## Date" in content
+    # Verify template content
+    content = template_file.read_text()
+    assert "# Architecture Decision Record (ADR)" in content
+    assert "## Title" in content
+    assert "## Status" in content
+    assert "## Date" in content
 
 
 @pytest.mark.e2e
-def test_init_command_with_existing_directory_continue() -> None:
+def test_init_command_with_existing_directory_continue(isolated_e2e_env: Path) -> None:
     """Test that init command handles existing directory with user confirmation."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        # Create existing directory
-        adr_dir = Path(tmpdir) / "docs/adr"
-        adr_dir.mkdir(parents=True, exist_ok=True)
+    # Create existing directory
+    adr_dir = isolated_e2e_env / "docs/adr"
+    adr_dir.mkdir(parents=True, exist_ok=True)
 
-        # Run init command and confirm continuation
-        child = pexpect.spawn("uv run adr-ai-tools init", cwd=tmpdir)
-        child.expect_exact("Directory 'docs/adr' already exists. Continue? (y/N):")
-        child.sendline("y")
-        child.expect_exact("Created docs/adr/ directory")
-        child.expect_exact("Generated template: docs/adr/0000-adr-template.md")
-        child.expect(pexpect.EOF)
-        child.close()
+    # Run init command and confirm continuation
+    child = pexpect.spawn("uv run adr-ai-tools init", cwd=isolated_e2e_env)
+    child.expect_exact("Directory 'docs/adr' already exists. Continue? (y/N):")
+    child.sendline("y")
+    child.expect_exact("Created docs/adr/ directory")
+    child.expect_exact("Generated template: docs/adr/0000-adr-template.md")
+    child.expect(pexpect.EOF)
+    child.close()
 
-        # Verify exit code
-        assert child.exitstatus == 0
+    # Verify exit code
+    assert child.exitstatus == 0
 
-        # Verify template was created
-        template_file = adr_dir / "0000-adr-template.md"
-        assert template_file.exists()
+    # Verify template was created
+    template_file = adr_dir / "0000-adr-template.md"
+    assert template_file.exists()
 
 
 @pytest.mark.e2e
-def test_init_command_with_existing_directory_cancel() -> None:
+def test_init_command_with_existing_directory_cancel(isolated_e2e_env: Path) -> None:
     """Test that init command handles existing directory with user cancellation."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        # Create existing directory
-        adr_dir = Path(tmpdir) / "docs/adr"
-        adr_dir.mkdir(parents=True, exist_ok=True)
+    # Create existing directory
+    adr_dir = isolated_e2e_env / "docs/adr"
+    adr_dir.mkdir(parents=True, exist_ok=True)
 
-        # Run init command and cancel
-        child = pexpect.spawn("uv run adr-ai-tools init", cwd=tmpdir)
-        child.expect_exact("Directory 'docs/adr' already exists. Continue? (y/N):")
-        child.sendline("n")
-        child.expect_exact("Initialization cancelled")
-        child.expect(pexpect.EOF)
-        child.close()
+    # Run init command and cancel
+    child = pexpect.spawn("uv run adr-ai-tools init", cwd=isolated_e2e_env)
+    child.expect_exact("Directory 'docs/adr' already exists. Continue? (y/N):")
+    child.sendline("n")
+    child.expect_exact("Initialization cancelled")
+    child.expect(pexpect.EOF)
+    child.close()
 
-        # Verify exit code
-        assert child.exitstatus == 0
+    # Verify exit code
+    assert child.exitstatus == 0
 
-        # Verify template was not created
-        template_file = adr_dir / "0000-adr-template.md"
-        assert not template_file.exists()
+    # Verify template was not created
+    template_file = adr_dir / "0000-adr-template.md"
+    assert not template_file.exists()

--- a/tests/e2e/test_init_with_config.py
+++ b/tests/e2e/test_init_with_config.py
@@ -1,0 +1,66 @@
+"""E2E tests for init command with configuration integration."""
+
+from pathlib import Path
+
+import pexpect
+import pytest
+
+from tests.e2e.conftest import ConfigCreator
+
+
+@pytest.mark.e2e
+def test_init_command_uses_configured_adr_directory(
+    isolated_e2e_env: Path, config_creator: ConfigCreator
+) -> None:
+    """Test that init command uses configured adr_directory instead of default."""
+    # Create a custom adr_directory configuration
+    config_creator(
+        {
+            "adr_directory": "custom/adr",
+            "template_file": "custom/adr/0000-adr-template.md",
+        }
+    )
+
+    # Run init command
+    child = pexpect.spawn("uv run adr-ai-tools init", cwd=isolated_e2e_env)
+    child.expect("Created custom/adr/ directory")
+    child.expect("Generated template: custom/adr/0000-adr-template.md")
+    child.expect(pexpect.EOF)
+    child.close()
+
+    # Verify exit code
+    assert child.exitstatus == 0
+
+    # Verify the custom directory was created
+    assert (isolated_e2e_env / "custom" / "adr").exists()
+    assert (isolated_e2e_env / "custom" / "adr" / "0000-adr-template.md").exists()
+
+    # Verify default directory was NOT created
+    assert not (isolated_e2e_env / "docs" / "adr").exists()
+
+
+@pytest.mark.e2e
+def test_init_command_uses_configured_template_file(
+    isolated_e2e_env: Path, config_creator: ConfigCreator
+) -> None:
+    """Test that init command uses configured template_file instead of default."""
+    # Create a custom template_file configuration (within adr_directory)
+    config_creator(
+        {"adr_directory": "docs/adr", "template_file": "docs/adr/custom-template.md"}
+    )
+
+    # Run init command
+    child = pexpect.spawn("uv run adr-ai-tools init", cwd=isolated_e2e_env)
+    child.expect("Created docs/adr/ directory")
+    child.expect("Generated template: docs/adr/custom-template.md")
+    child.expect(pexpect.EOF)
+    child.close()
+
+    # Verify exit code
+    assert child.exitstatus == 0
+
+    # Verify the custom template was created
+    assert (isolated_e2e_env / "docs" / "adr" / "custom-template.md").exists()
+
+    # Verify default template was NOT created
+    assert not (isolated_e2e_env / "docs" / "adr" / "0000-adr-template.md").exists()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,76 @@
+"""Unit test fixtures."""
+
+from pathlib import Path
+from typing import NamedTuple
+from unittest.mock import Mock
+
+import pytest
+
+from adraitools.models.configuration import AdrConfiguration
+from adraitools.services.adr_initializer import AdrInitializer
+from adraitools.services.configuration_service import ConfigurationService
+from adraitools.services.file_system_service import FileSystemService
+from adraitools.services.user_interaction_service import UserInteractionService
+
+
+class MockServices(NamedTuple):
+    """Container for mocked services."""
+
+    file_system: Mock
+    user_interaction: Mock
+    configuration: Mock
+
+
+class InitializerTestSetup(NamedTuple):
+    """Container for initializer test setup."""
+
+    initializer: AdrInitializer
+    mocks: MockServices
+
+
+@pytest.fixture
+def mock_services() -> MockServices:
+    """Create mock services for testing."""
+    return MockServices(
+        file_system=Mock(spec=FileSystemService),
+        user_interaction=Mock(spec=UserInteractionService),
+        configuration=Mock(spec=ConfigurationService),
+    )
+
+
+@pytest.fixture
+def default_config() -> AdrConfiguration:
+    """Create default configuration for testing."""
+    return AdrConfiguration(
+        adr_directory=Path("docs/adr"),
+        template_file=Path("docs/adr/0000-adr-template.md"),
+    )
+
+
+@pytest.fixture
+def custom_config() -> AdrConfiguration:
+    """Create custom configuration for testing."""
+    return AdrConfiguration(
+        adr_directory=Path("custom/adr"),
+        template_file=Path("custom/adr/0000-adr-template.md"),
+    )
+
+
+@pytest.fixture
+def custom_template_config() -> AdrConfiguration:
+    """Create configuration with custom template file for testing."""
+    return AdrConfiguration(
+        adr_directory=Path("docs/adr"),
+        template_file=Path("custom/template.md"),
+    )
+
+
+@pytest.fixture
+def initializer_setup(mock_services: MockServices) -> InitializerTestSetup:
+    """Create AdrInitializer with mocked services."""
+    initializer = AdrInitializer(
+        mock_services.file_system,
+        mock_services.user_interaction,
+        mock_services.configuration,
+    )
+    return InitializerTestSetup(initializer=initializer, mocks=mock_services)

--- a/tests/unit/test_adr_initializer.py
+++ b/tests/unit/test_adr_initializer.py
@@ -1,98 +1,155 @@
 """Unit tests for ADR initializer."""
 
 from pathlib import Path
-from unittest.mock import Mock
 
-from adraitools.services.adr_initializer import AdrInitializer
-from adraitools.services.file_system_service import FileSystemService
-from adraitools.services.user_interaction_service import UserInteractionService
+from adraitools.models.configuration import AdrConfiguration
+from tests.unit.conftest import InitializerTestSetup
 
 
-def test_initialize_creates_directory_and_template() -> None:
+def test_initialize_creates_directory_and_template(
+    initializer_setup: InitializerTestSetup, default_config: AdrConfiguration
+) -> None:
     """Test that initialize creates directory and template file."""
     # Arrange
-    file_system_service = Mock(spec=FileSystemService)
-    user_interaction_service = Mock(spec=UserInteractionService)
-    file_system_service.directory_exists.return_value = False
-
-    initializer = AdrInitializer(file_system_service, user_interaction_service)
+    initializer_setup.mocks.file_system.directory_exists.return_value = False
+    initializer_setup.mocks.configuration.get_configuration.return_value = (
+        default_config
+    )
 
     # Act
-    result = initializer.initialize()
+    result = initializer_setup.initializer.initialize()
 
     # Assert
     assert result.success is True
     assert result.message == "ADR directory structure initialized successfully"
-    file_system_service.create_directory.assert_called_once_with(Path("docs/adr"))
-    file_system_service.create_template_file.assert_called_once_with(
+    initializer_setup.mocks.file_system.create_directory.assert_called_once_with(
+        Path("docs/adr")
+    )
+    initializer_setup.mocks.file_system.create_template_file.assert_called_once_with(
         Path("docs/adr/0000-adr-template.md")
     )
-    user_interaction_service.ask_confirmation.assert_not_called()
+    initializer_setup.mocks.user_interaction.ask_confirmation.assert_not_called()
+    initializer_setup.mocks.configuration.get_configuration.assert_called_once()
 
 
-def test_initialize_with_existing_directory_user_confirms() -> None:
+def test_initialize_with_existing_directory_user_confirms(
+    initializer_setup: InitializerTestSetup, default_config: AdrConfiguration
+) -> None:
     """Test initialize with existing directory when user confirms."""
     # Arrange
-    file_system_service = Mock(spec=FileSystemService)
-    user_interaction_service = Mock(spec=UserInteractionService)
-    file_system_service.directory_exists.return_value = True
-    user_interaction_service.ask_confirmation.return_value = True
-
-    initializer = AdrInitializer(file_system_service, user_interaction_service)
+    initializer_setup.mocks.file_system.directory_exists.return_value = True
+    initializer_setup.mocks.user_interaction.ask_confirmation.return_value = True
+    initializer_setup.mocks.configuration.get_configuration.return_value = (
+        default_config
+    )
 
     # Act
-    result = initializer.initialize()
+    result = initializer_setup.initializer.initialize()
 
     # Assert
     assert result.success is True
     assert result.message == "ADR directory structure initialized successfully"
-    file_system_service.create_directory.assert_called_once_with(Path("docs/adr"))
-    file_system_service.create_template_file.assert_called_once_with(
+    initializer_setup.mocks.file_system.create_directory.assert_called_once_with(
+        Path("docs/adr")
+    )
+    initializer_setup.mocks.file_system.create_template_file.assert_called_once_with(
         Path("docs/adr/0000-adr-template.md")
     )
-    user_interaction_service.ask_confirmation.assert_called_once_with(
+    initializer_setup.mocks.user_interaction.ask_confirmation.assert_called_once_with(
         "Directory 'docs/adr' already exists. Continue? (y/N)"
     )
 
 
-def test_initialize_with_existing_directory_user_cancels() -> None:
+def test_initialize_with_existing_directory_user_cancels(
+    initializer_setup: InitializerTestSetup, default_config: AdrConfiguration
+) -> None:
     """Test initialize with existing directory when user cancels."""
     # Arrange
-    file_system_service = Mock(spec=FileSystemService)
-    user_interaction_service = Mock(spec=UserInteractionService)
-    file_system_service.directory_exists.return_value = True
-    user_interaction_service.ask_confirmation.return_value = False
-
-    initializer = AdrInitializer(file_system_service, user_interaction_service)
+    initializer_setup.mocks.file_system.directory_exists.return_value = True
+    initializer_setup.mocks.user_interaction.ask_confirmation.return_value = False
+    initializer_setup.mocks.configuration.get_configuration.return_value = (
+        default_config
+    )
 
     # Act
-    result = initializer.initialize()
+    result = initializer_setup.initializer.initialize()
 
     # Assert
     assert result.success is False
     assert result.message == "Initialization cancelled"
-    file_system_service.create_directory.assert_not_called()
-    file_system_service.create_template_file.assert_not_called()
-    user_interaction_service.ask_confirmation.assert_called_once_with(
+    initializer_setup.mocks.file_system.create_directory.assert_not_called()
+    initializer_setup.mocks.file_system.create_template_file.assert_not_called()
+    initializer_setup.mocks.user_interaction.ask_confirmation.assert_called_once_with(
         "Directory 'docs/adr' already exists. Continue? (y/N)"
     )
 
 
-def test_initialize_handles_file_system_error() -> None:
+def test_initialize_handles_file_system_error(
+    initializer_setup: InitializerTestSetup, default_config: AdrConfiguration
+) -> None:
     """Test that initialize handles file system errors gracefully."""
     # Arrange
-    file_system_service = Mock(spec=FileSystemService)
-    user_interaction_service = Mock(spec=UserInteractionService)
-    file_system_service.directory_exists.return_value = False
-    file_system_service.create_directory.side_effect = OSError("Permission denied")
-
-    initializer = AdrInitializer(file_system_service, user_interaction_service)
+    initializer_setup.mocks.file_system.directory_exists.return_value = False
+    initializer_setup.mocks.file_system.create_directory.side_effect = OSError(
+        "Permission denied"
+    )
+    initializer_setup.mocks.configuration.get_configuration.return_value = (
+        default_config
+    )
 
     # Act
-    result = initializer.initialize()
+    result = initializer_setup.initializer.initialize()
 
     # Assert
     assert result.success is False
     assert "Permission denied" in result.message
-    file_system_service.create_directory.assert_called_once_with(Path("docs/adr"))
-    file_system_service.create_template_file.assert_not_called()
+    initializer_setup.mocks.file_system.create_directory.assert_called_once_with(
+        Path("docs/adr")
+    )
+    initializer_setup.mocks.file_system.create_template_file.assert_not_called()
+
+
+def test_initialize_uses_configured_adr_directory(
+    initializer_setup: InitializerTestSetup, custom_config: AdrConfiguration
+) -> None:
+    """Test that initialize uses configured adr_directory instead of default."""
+    # Arrange
+    initializer_setup.mocks.file_system.directory_exists.return_value = False
+    initializer_setup.mocks.configuration.get_configuration.return_value = custom_config
+
+    # Act
+    result = initializer_setup.initializer.initialize()
+
+    # Assert
+    assert result.success is True
+    initializer_setup.mocks.file_system.create_directory.assert_called_once_with(
+        Path("custom/adr")
+    )
+    initializer_setup.mocks.file_system.create_template_file.assert_called_once_with(
+        Path("custom/adr/0000-adr-template.md")
+    )
+    initializer_setup.mocks.configuration.get_configuration.assert_called_once()
+
+
+def test_initialize_uses_configured_template_file(
+    initializer_setup: InitializerTestSetup, custom_template_config: AdrConfiguration
+) -> None:
+    """Test that initialize uses configured template_file instead of default."""
+    # Arrange
+    initializer_setup.mocks.file_system.directory_exists.return_value = False
+    initializer_setup.mocks.configuration.get_configuration.return_value = (
+        custom_template_config
+    )
+
+    # Act
+    result = initializer_setup.initializer.initialize()
+
+    # Assert
+    assert result.success is True
+    initializer_setup.mocks.file_system.create_directory.assert_called_once_with(
+        Path("docs/adr")
+    )
+    initializer_setup.mocks.file_system.create_template_file.assert_called_once_with(
+        Path("custom/template.md")
+    )
+    initializer_setup.mocks.configuration.get_configuration.assert_called_once()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -20,6 +20,12 @@ def test_init_command_success(mocker: MockerFixture) -> None:
     )
     mock_initializer.initialize.return_value = success_result
 
+    # Mock the ConfigurationService to return predictable values
+    mock_config_service = mocker.patch("adraitools.cli.ConfigurationService")
+    mock_config = mock_config_service.return_value.get_configuration.return_value
+    mock_config.adr_directory = "docs/adr"
+    mock_config.template_file = "docs/adr/0000-adr-template.md"
+
     # Act
     result = runner.invoke(app, ["init"])
 


### PR DESCRIPTION
# Pull Request Overview
Integrate configuration system with init command to use configured values instead of hardcoded defaults, and refactor tests with type-safe fixtures using Protocol types and NamedTuple.

## Changes
- Connect configuration system to init command behavior (Issue #23)
- Refactor AdrInitializer to use ConfigurationService for dynamic configuration
- Update CLI to inject ConfigurationService and display configured paths
- Implement type-safe test fixtures using Protocol types and NamedTuple
- Add comprehensive E2E tests for configuration integration
- Create ADRs for Protocol types and structured test fixture organization

## Related Issues
- Fixes #23

## Test Details
- All 77 tests pass
- Added E2E tests verifying init command uses configured adr_directory and template_file
- Unit tests cover ConfigurationService integration with AdrInitializer
- Type safety verified with mypy
- Code quality maintained with ruff linting

## Future Work
- Consider extending configuration integration to other commands as they are implemented
- Monitor fixture usage patterns for further optimization

## Notes
- Maintains backward compatibility with existing functionality