### PR TITLE
feat: enhance logging integration tests to validate timestamp format

### DIFF
--- a/tests/integration/test_logging_integration.py
+++ b/tests/integration/test_logging_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for logging functionality."""
 
 import logging
+import re
 import tempfile
 from pathlib import Path
 
@@ -111,8 +112,9 @@ class TestLoggingIntegration:
             # File should have timestamp format
             assert "INFO" in content
             assert "Format test message" in content
-            # Should contain timestamp pattern
-            assert " - " in content
+            # Should contain timestamp pattern (YYYY-MM-DD HH:MM:SS,mmm - LEVEL: message)
+            timestamp_pattern = r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} - INFO: Format test message'
+            assert re.search(timestamp_pattern, content), f"Expected timestamp pattern not found in: {content}"
 
     def test_logging_service_custom_format(self) -> None:
         """Test that custom log format is applied correctly."""

--- a/tests/integration/test_logging_integration.py
+++ b/tests/integration/test_logging_integration.py
@@ -112,9 +112,13 @@ class TestLoggingIntegration:
             # File should have timestamp format
             assert "INFO" in content
             assert "Format test message" in content
-            # Should contain timestamp pattern (YYYY-MM-DD HH:MM:SS,mmm - LEVEL: message)
-            timestamp_pattern = r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} - INFO: Format test message'
-            assert re.search(timestamp_pattern, content), f"Expected timestamp pattern not found in: {content}"
+            # Should contain timestamp pattern
+            timestamp_pattern = (
+                r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} - INFO: Format test message"
+            )
+            assert re.search(timestamp_pattern, content), (
+                f"Expected timestamp pattern not found in: {content}"
+            )
 
     def test_logging_service_custom_format(self) -> None:
         """Test that custom log format is applied correctly."""


### PR DESCRIPTION
# Pull Request Overview
This PR improves the logging integration test assertions by clarifying test intentions and replacing ambiguous timestamp validation with explicit regular expression pattern matching.

## Changes
- **Clarified test intentions**: Replaced ambiguous `assert " - " in content` with explicit timestamp pattern validation that clearly expresses what we're testing
- **Enhanced test readability**: The test now explicitly validates the complete log format structure including timestamp, level, and message format
- **Better error reporting**: Added descriptive error message showing actual content when pattern matching fails

### Test Changes
- Modified `test_logging_service_default_format()` in `tests/integration/test_logging_integration.py`
- Changed from unclear validation (checking for hyphen presence) to intention-revealing validation (regex pattern matching)
- Pattern validates: `YYYY-MM-DD HH:MM:SS,mmm - LEVEL: message` format

## Related Issues
- Part of ongoing logging service integration improvements (related to issue #26)

## Test Details
- **Existing functionality preserved**: All existing test cases continue to pass
- **Clarified test intentions**: The timestamp validation now explicitly expresses what we're testing - that file logging includes timestamps in a specific format
- **Pattern validation**: Uses regex `r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} - INFO: Format test message'` to validate complete log entry format
- **Error diagnostics**: Improved error messages help identify format issues during test failures

### Testing Performed
- Ran integration tests to verify the improved assertion works correctly
- Verified that the pattern matches the actual log format produced by LoggingService
- Confirmed that test failure scenarios provide useful diagnostic information

## Future Work
- Consider applying similar pattern-based validation to other logging test methods

## Notes
This change primarily improves test clarity and intention expression without affecting production code. The previous assertion using `" - "` was testing an implementation detail indirectly and did not clearly communicate what behavior was being verified.

**The key improvement is test intention clarity**: The new regex pattern explicitly states that we want to ensure file logging includes timestamps in a specific format (`YYYY-MM-DD HH:MM:SS,mmm - LEVEL: message`), rather than just checking that hyphens appear somewhere in the log content. 

This makes the test self-documenting and helps future maintainers understand exactly what logging behavior is being validated.
